### PR TITLE
Ensure pagination totals never drop below one

### DIFF
--- a/Panorama.php
+++ b/Panorama.php
@@ -37,8 +37,10 @@ class Panorama {
         
         $sql = "SELECT COUNT(*) as total FROM " . DB_TABLE . " $whereClause";
         $result = $this->db->query($sql, $params)->fetch();
-        
-        return ceil($result['total'] / $perPage);
+
+        $totalRecords = (int)($result['total'] ?? 0);
+
+        return max(1, (int)ceil($totalRecords / $perPage));
     }
     
     public function addPanorama($data) {


### PR DESCRIPTION
## Summary
- guard the total page calculation against empty result sets so pagination never links to page 0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690771e9c91c832e892da53f564e4806